### PR TITLE
Note on _user_id as internal variable in DBAuth

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -629,6 +629,8 @@ With this, you can log into `/db` as `alpha` and `alpha`, etc. It displays a
 [minimal HTML template][auth-template] that asks for an ID and password, and
 matches it with the `auth.xlsx` database.
 
+**Note** - Do not name user column as `_user_id` as it's an internal variable.
+
 <div class="example">
   <a class="example-demo" href="dbsimple">DBAuth example</a>
   <a class="example-src" href="https://github.com/gramexrecipes/gramex-guide/blob/master/auth/gramex.yaml">Source</a>


### PR DESCRIPTION
introduces a note on `_user_id` being an internal variable.

Fixes https://github.com/gramener/gramex/issues/195