### PR TITLE
Update vega invocation for v4

### DIFF
--- a/tutorials/quickstart/README.md
+++ b/tutorials/quickstart/README.md
@@ -279,7 +279,7 @@ var spec = {
     }
   }
 }
-var view = new vega.View(vega.parse(vl.compile(spec).spec))
+var view = new vega.View(vega.parse(vegaLite.compile(spec).spec))
     .renderer('svg')
     .initialize('#chart')
     .hover()
@@ -313,7 +313,7 @@ the div to draw the chart, the x-axis column name and the title of the chart.
 function render_charts(chartid, xfield, title) {
   spec.title.text = title
   spec.encoding.x.field = xfield
-  var view = new vega.View(vega.parse(vl.compile(spec).spec))
+  var view = new vega.View(vega.parse(vegaLite.compile(spec).spec))
     .renderer('svg')
     .initialize(chartid)
     .hover()

--- a/tutorials/quickstart/output/index.html
+++ b/tutorials/quickstart/output/index.html
@@ -44,7 +44,7 @@
         }
       }
     }
-    var view = new vega.View(vega.parse(vl.compile(spec).spec))
+    var view = new vega.View(vega.parse(vegaLite.compile(spec).spec))
         .renderer('svg')
         .initialize('#chart')
         .hover()
@@ -98,7 +98,7 @@
       spec.title.text = title
       spec.encoding.x.field = xfield
       spec.encoding.color.field = xfield
-      var view = new vega.View(vega.parse(vl.compile(spec).spec))
+      var view = new vega.View(vega.parse(vegaLite.compile(spec).spec))
         .renderer('svg')
         .initialize(chartid)
         .hover()


### PR DESCRIPTION
Vega was invoked using `vl` in v3. With `v4` it's changed to `vegaLite`.

This change reflects it in documentation and the corresponding output HTML page.

Fixes #21 