### PR TITLE
DOC: link gramex ml workshop material

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -9,7 +9,7 @@ List of current tutorials:
 2. [Interactive Dashboards with Gramex](dashboards/)
 3. [Interactive Charts with Gramex](charts/)
 4. [Dropdown Menus & Search](g1-dropdown/)
-
+5. [Create a ML classification application](https://github.com/gramexrecipes/gramex-ml-workshop)
 
 Feature Documentation:
 


### PR DESCRIPTION
Over few workshops at PyConf, SciPy and with clients we curated material at https://github.com/gramexrecipes/gramex-ml-workshop

It introduces the following material in 1.5 hrs:

- introduction to gramex, web interactions
- build a machine learning classification application
- explore possibilities with gramex