### PR TITLE
DOC: Fix instructions to update Gramex

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -42,7 +42,7 @@ Run `gramex --help` to verify that Gramex is installed.
 To upgrade Gramex, run:
 
 ```bash
-conda update gramex
+conda update -c conda-forge -c gramener gramex
 ```
 
 ## Docker install


### PR DESCRIPTION
Simply running `conda update gramex` does not upgrade Gramex. See gramener/gramex#362