### PR TITLE
ENH: Add `ilike` to formhandler

### DIFF
--- a/formhandler/README.md
+++ b/formhandler/README.md
@@ -262,6 +262,10 @@ The URL supports operators for filtering rows. The operators can be combined.
 - [?c1>=10&c1<=20](flags?c1>=10&c1<=20&_format=html) ► c1 > 10 AND c1 < 20
 - [?Name~=United](flags?Name~=United&_format=html) ► Name matches &_format=html
 - [?Name!~=United](flags?Name!~=United&_format=html) ► Name does NOT match United
+- [?Name*=United](flags?Name*=United&_format=html) ► Name matches case insensitive &_format=html
+- [?Name*=United](flags?Name*=united&_format=html) ► Name matches case insensitive &_format=html
+- [?Name!*=United](flags?Name!*=United&_format=html) ► Name does NOT match case insensitive United
+- [?Name!*=United](flags?Name!*=united&_format=html) ► Name does NOT match case insensitive united
 - [?Name~=United&Continent=Asia](flags?Name~=United&Continent=Asia&_format=html) ► Name matches United AND Continent is Asia
 
 To control the output, you can use these control arguments:


### PR DESCRIPTION
# Fix: https://github.com/gramener/gramex/issues/681

FormHandler should support case insensitive comparison

Add: `*` for `ilike (case insensitive like)` and `!*` for `not-ilike` ;  `Similar to `\~` for `like` / `!~` for `not-like`.
fixing: 
## Test

![image](https://user-images.githubusercontent.com/5307399/225819038-24df68de-df54-4aee-80da-4581df683729.png)
